### PR TITLE
add an endpoint to return a POJO

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -31,3 +31,29 @@ editor:
     - "encryptedDockerRegistryToken": "C**********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************="
     - "encryptedDockerRegistryUser": "2**********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************="
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddRestEndpoint"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "0.11.9"
+  origin:
+    repo: "git@github.com:satellite-of-love/rest-service-generator"
+    branch: "restrict-cors"
+    sha: "e241a51"
+  parameters:
+    - "returnedClass": "SurveyOptions"
+    - "fieldName": "seed"
+    - "fieldType": "int"
+    - "repo": "random-kitty-adoption"
+    - "handle": "{}"
+    - "__mappedParameters": "{"0":{"localKey":"repo","foreignKey":"atomist://github/repository"}}"
+    - "__parameters": "{"0":{"displayName":"Java return type","description":"type the endpoint will return","pattern":"@java_class","validInput":"Java class name like ThunderCougarFalconBird","minLength":1,"maxLength":100,"name":"returnedClass","decorated":true},"1":{"displayName":"pojo field name","description":"name of a field in your pojo, blank for none (or not a new pojo)","pattern":"@java_identifier","validInput":"Java identifier","minLength":1,"maxLength":100,"name":"fieldName","decorated":true},"2":{"displayName":"pojo field type","description":"type of that field in your pojo, blank for none (or not a new pojo)","pattern":"@any","validInput":"Java type","minLength":1,"maxLength":100,"name":"fieldType","decorated":true}}"
+    - "__intent": "{"0":"add endpoint"}"
+    - "__tags": "{"0":"satellite-of-love","1":"rest"}"
+    - "__name": "AddRestEndpointPlease"
+    - "__description": "run an editor to add a REST endpoint to this project"
+    - "__kind": "command-handler"
+

--- a/src/main/java/com/jessitron/SurveyOption.java
+++ b/src/main/java/com/jessitron/SurveyOption.java
@@ -1,0 +1,55 @@
+package com.jessitron;
+
+public class SurveyOption {
+
+    public SurveyOption() {}
+
+    private String imageLocation;
+    private String text;
+    private int place;
+
+    public void setImageLocation(String imageLocation) {
+        this.imageLocation = imageLocation;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public int getPlace() {
+        return place;
+    }
+
+    public void setPlace(int place) {
+        this.place = place;
+    }
+
+    public String getImageLocation() {
+        return imageLocation;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public SurveyOption(String imageLocation, String text) {
+        this.imageLocation = imageLocation;
+        this.text = text;
+        this.place = 0;
+    }
+
+    public SurveyOption withPlace(int place) {
+        SurveyOption copy = new SurveyOption(this.imageLocation, this.text);
+        copy.setPlace(place);
+        return copy;
+    }
+
+    @Override
+    public String toString() {
+        return "SurveyOption{" +
+                "imageLocation='" + imageLocation + '\'' +
+                ", text='" + text + '\'' +
+                ", place=" + place +
+                '}';
+    }
+}

--- a/src/main/java/com/jessitron/SurveyOptions.java
+++ b/src/main/java/com/jessitron/SurveyOptions.java
@@ -1,19 +1,41 @@
 package com.jessitron;
 
-public class SurveyOptions {
-    
-    private int seed;
+import java.util.List;
 
-    public SurveyOptions(int seed) {
+public class SurveyOptions {
+
+    private String surveyName;
+    private int seed;
+    private List<SurveyOption> options;
+
+    public SurveyOptions(String surveyName, int seed, List<SurveyOption> options) {
+        this.surveyName = surveyName;
         this.seed = seed;
+        this.options = options;
     }
 
-    public int getSeed () {
+    public int getSeed() {
         return seed;
     }
 
-    public void setSeed (int seed) {
+    public void setSeed(int seed) {
         this.seed = seed;
+    }
+
+    public List<SurveyOption> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<SurveyOption> options) {
+        this.options = options;
+    }
+
+    public String getSurveyName () {
+        return surveyName;
+    }
+
+    public void setSurveyName (String surveyName) {
+        this.surveyName = surveyName;
     }
 
     // don't forget the default constructor. Jackson likes it

--- a/src/main/java/com/jessitron/SurveyOptions.java
+++ b/src/main/java/com/jessitron/SurveyOptions.java
@@ -1,0 +1,21 @@
+package com.jessitron;
+
+public class SurveyOptions {
+    
+    private int seed;
+
+    public SurveyOptions(int seed) {
+        this.seed = seed;
+    }
+
+    public int getSeed () {
+        return seed;
+    }
+
+    public void setSeed (int seed) {
+        this.seed = seed;
+    }
+
+    // don't forget the default constructor. Jackson likes it
+    public SurveyOptions () {}
+}

--- a/src/main/java/com/jessitron/SurveyOptionsController.java
+++ b/src/main/java/com/jessitron/SurveyOptionsController.java
@@ -5,13 +5,57 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 @RestController
 public class SurveyOptionsController {
 
     @CrossOrigin()
     @RequestMapping(path = "/surveyOptions")
-    public SurveyOptions surveyOptions(@RequestParam(value = "seed") int seed) {
-        return new SurveyOptions(seed);
+    public SurveyOptions surveyOptions(@RequestParam(value = "seed") int seed)
+    {
+        return new SurveyOptions("Survey " + seed, seed, threeRandomOptions(seed));
+    }
+
+
+    private List<SurveyOption> threeRandomOptions(int seed) {
+        List<SurveyOption> local = new ArrayList<>(allOptions);
+        Collections.shuffle(local, new Random(seed)); // this actually modifies the list ugh
+        List<SurveyOption> withIndices = IntStream.range(0, local.size())
+                .mapToObj(i -> local.get(i).withPlace(i + 1))
+                .limit(3)
+                .collect(Collectors.toList());
+
+        return withIndices;
+    }
+
+
+    private final List<SurveyOption> allOptions;
+
+    { /* static initializer */
+        allOptions = new LinkedList<>();
+        allOptions.add(
+                new SurveyOption(
+                        "https://upload.wikimedia.org/wikipedia/commons/1/16/Kitty_meowing.jpg",
+                        "kitty meowing"));
+        allOptions.add(
+                new SurveyOption(
+                        "https://c1.staticflickr.com/4/3149/2988746750_4a3dfdee59.jpg",
+                        "sink kitties"));
+        allOptions.add(
+                new SurveyOption(
+                        "http://www.publicdomainpictures.net/pictures/60000/velka/green-eyed-kitty.jpg",
+                        "green-eyed kitty"));
+        allOptions.add(
+                new SurveyOption(
+                        "http://maxpixel.freegreatpicture.com/static/photo/1x/Sweet-Animals-Kitty-Cat-323262.jpg",
+                        "kitty licking paw"));
+        allOptions.add(
+                new SurveyOption(
+                        "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Computer-kitten.jpg/1024px-Computer-kitten.jpg",
+                        "computer kitten"));
     }
 
 }

--- a/src/main/java/com/jessitron/SurveyOptionsController.java
+++ b/src/main/java/com/jessitron/SurveyOptionsController.java
@@ -1,0 +1,18 @@
+package com.jessitron;
+
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SurveyOptionsController {
+
+    @CrossOrigin()
+    @RequestMapping(path = "/surveyOptions")
+    public SurveyOptions surveyOptions(@RequestParam(value = "seed") int seed) {
+        return new SurveyOptions(seed);
+    }
+
+}
+    

--- a/src/test/java/com/jessitron/SurveyOptionsWebIntegrationTests.java
+++ b/src/test/java/com/jessitron/SurveyOptionsWebIntegrationTests.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = ChangeMeApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = RandomittydoptionApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 public class SurveyOptionsWebIntegrationTests {
 
     @Autowired
@@ -21,8 +21,8 @@ public class SurveyOptionsWebIntegrationTests {
     
     @Test
     public void surveyOptionsTest() {
-        SurveyOptions result = restTemplate.getForObject("/surveyOptions?seed=hello", SurveyOptions.class);
-        assertEquals("hello", result.getSeed());
+        SurveyOptions result = restTemplate.getForObject("/surveyOptions?seed=33", SurveyOptions.class);
+        assertEquals(33, result.getSeed());
     }
     
 }

--- a/src/test/java/com/jessitron/SurveyOptionsWebIntegrationTests.java
+++ b/src/test/java/com/jessitron/SurveyOptionsWebIntegrationTests.java
@@ -1,0 +1,28 @@
+package com.jessitron;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = ChangeMeApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+public class SurveyOptionsWebIntegrationTests {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    
+    @Test
+    public void surveyOptionsTest() {
+        SurveyOptions result = restTemplate.getForObject("/surveyOptions?seed=hello", SurveyOptions.class);
+        assertEquals("hello", result.getSeed());
+    }
+    
+}


### PR DESCRIPTION
Created by Atomist Editor `AddRestEndpoint`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddRestEndpoint"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "0.11.9"
  origin:
    repo: "git@github.com:satellite-of-love/rest-service-generator"
    branch: "restrict-cors"
    sha: "e241a51"
  parameters:
    - "returnedClass": "SurveyOptions"
    - "fieldName": "seed"
    - "fieldType": "int"
    - "repo": "random-kitty-adoption"
    - "handle": "{}"
    - "__mappedParameters": "{"0":{"localKey":"repo","foreignKey":"atomist://github/repository"}}"
    - "__parameters": "{"0":{"displayName":"Java return type","description":"type the endpoint will return","pattern":"@java_class","validInput":"Java class name like ThunderCougarFalconBird","minLength":1,"maxLength":100,"name":"returnedClass","decorated":true},"1":{"displayName":"pojo field name","description":"name of a field in your pojo, blank for none (or not a new pojo)","pattern":"@java_identifier","validInput":"Java identifier","minLength":1,"maxLength":100,"name":"fieldName","decorated":true},"2":{"displayName":"pojo field type","description":"type of that field in your pojo, blank for none (or not a new pojo)","pattern":"@any","validInput":"Java type","minLength":1,"maxLength":100,"name":"fieldType","decorated":true}}"
    - "__intent": "{"0":"add endpoint"}"
    - "__tags": "{"0":"satellite-of-love","1":"rest"}"
    - "__name": "AddRestEndpointPlease"
    - "__description": "run an editor to add a REST endpoint to this project"
    - "__kind": "command-handler"

```