### PR TITLE
Add a restriction to CrossOrigin annotations

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -57,3 +57,16 @@ editor:
     - "__description": "run an editor to add a REST endpoint to this project"
     - "__kind": "command-handler"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "RestrictCORS"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "0.12.9"
+  origin:
+    repo: "git@github.com:satellite-of-love/workflow-rugs"
+    branch: "master"
+    sha: "e5b95e2"
+

--- a/src/main/java/com/jessitron/SurveyOptionsController.java
+++ b/src/main/java/com/jessitron/SurveyOptionsController.java
@@ -12,7 +12,7 @@ import java.util.stream.IntStream;
 @RestController
 public class SurveyOptionsController {
 
-    @CrossOrigin()
+    @CrossOrigin(origins = "http://localhost:8000")
     @RequestMapping(path = "/surveyOptions")
     public SurveyOptions surveyOptions(@RequestParam(value = "seed") int seed)
     {


### PR DESCRIPTION
This is a recommended change from your friendly security advisers.
        
        While allowing cross-origin requests is essential for some local testing, it is 
        otherwise discouraged by ... people. As long as your local front end is at localhost:8080,
        you'll be able to test.

        If there is a particular reason that your service should allow more requests (like, it's a public API)
        then please comment on this PR and then close it or remove individual endpoints' changes.
        

Created by Atomist Editor `RestrictCORS`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "RestrictCORS"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "0.12.9"
  origin:
    repo: "git@github.com:satellite-of-love/workflow-rugs"
    branch: "master"
    sha: "e5b95e2"

```